### PR TITLE
Add support for loading username and password from environment

### DIFF
--- a/cmd/webdav/main.go
+++ b/cmd/webdav/main.go
@@ -77,9 +77,33 @@ func parseUsers(raw []map[string]interface{}, c *cfg) {
 			log.Fatal("user needs an username")
 		}
 
+		// load username from environment when prefix {env} is added
+		if strings.HasPrefix(username, "{env}") {
+			var envUsername = strings.TrimPrefix(username, "{env}")
+			if envUsername == "" {
+				log.Fatal("no environment variable specified for username")
+			}
+			username = os.Getenv(envUsername)
+			if username == "" {
+				log.Fatal("username must be set in environment")
+			}
+		}
+
 		password, ok := r["password"].(string)
 		if !ok {
 			log.Fatal("user needs a password")
+		}
+
+		// load password from environment when prefix {env} is added
+		if strings.HasPrefix(password, "{env}") {
+			var envPassword = strings.TrimPrefix(password, "{env}")
+			if envPassword == "" {
+				log.Fatal("no environment variable specified for password")
+			}
+			password = os.Getenv(envPassword)
+			if password == "" {
+				log.Fatal("password must be set in environment")
+			}
 		}
 
 		c.auth[username] = password

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,8 @@ users:
     password: admin
   - username: encrypted
     password: "{bcrypt}$2y$10$zEP6oofmXFeHaeMfBNLnP.DO8m.H.Mwhd24/TOX2MWLxAExXi4qgi"
+  - username: "{env}ENV_USERNAME"
+    password: "{env}ENV_PASSWORD"
   - username: basic
     password: basic
     modify:   false


### PR DESCRIPTION
Hello,

thanks for your great tool. I want to use it in a docker based environment and need to supply username and password via the environment.
This allows to load username and password from environment variables specified in the config. It is implemented in the same non-breaking way as bcrypt support. I added an example in the readme.

Best,
Christian