### PR TITLE
feat: add URL prefix(subpath) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ auth: true
 tls: false
 cert: cert.pem
 key: key.pem
+prefix: /
 
 # Default user settings (will be merged)
 scope: .

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -114,6 +114,7 @@ func parseUsers(raw []interface{}, c *webdav.Config) {
 			}
 
 			user.Handler = &wd.Handler{
+				Prefix: c.User.Handler.Prefix,
 				FileSystem: wd.Dir(user.Scope),
 				LockSystem: wd.NewMemLS(),
 			}
@@ -170,6 +171,7 @@ func readConfig(flags *pflag.FlagSet) *webdav.Config {
 			Modify: getOptB(flags, "modify"),
 			Rules:  []*webdav.Rule{},
 			Handler: &wd.Handler{
+				Prefix: getOpt(flags, "prefix"),
 				FileSystem: wd.Dir(getOpt(flags, "scope")),
 				LockSystem: wd.NewMemLS(),
 			},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ func init() {
 	flags.String("key", "key.pem", "TLS key")
 	flags.StringP("address", "a", "0.0.0.0", "address to listen to")
 	flags.StringP("port", "p", "0", "port to listen to")
+	flags.StringP("prefix", "P", "/", "URL path prefix")
 }
 
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
To adapt to situations such as working behind a reverse proxy dispatching query to different services by URL path prefix.