### PR TITLE
fix: GET directory fails when non-root prefix configured

### DIFF
--- a/lib/webdav.go
+++ b/lib/webdav.go
@@ -127,8 +127,8 @@ func (c *Config) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	//		the collection, or something else altogether.
 	//
 	// Get, when applied to collection, will return the same as PROPFIND method.
-	if r.Method == "GET" {
-		info, err := u.Handler.FileSystem.Stat(context.TODO(), r.URL.Path)
+	if r.Method == "GET" && strings.HasPrefix(r.URL.Path, u.Handler.Prefix) {
+		info, err := u.Handler.FileSystem.Stat(context.TODO(), strings.TrimPrefix(r.URL.Path, u.Handler.Prefix))
 		if err == nil && info.IsDir() {
 			r.Method = "PROPFIND"
 


### PR DESCRIPTION
The URL prefix was not considered when replacing the "GET" method on directories to "PROPFIND". This  PR fixes this.