### PR TITLE
chore: build the binary statically to fix the docker image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 env:
   - GO111MODULE=on
+  - CGO_ENABLED=0
 
 before:
   hooks:


### PR DESCRIPTION
Currently running the published Docker image fails with `standard_init_linux.go:211: exec user process caused "no such file or directory"`. This is because the currently built and provided binaries being dynamically linked due to CGO being enabled. Running ldd against the current binaries shows:
```shell
~$ ldd webdav
	linux-vdso.so.1 (0x00007fff9ffc3000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f6cb2ad0000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f6cb26df000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f6cb2cef000)
```
So copying this binary into `scratch` image causes the executable to fail because it can't find the shared libraries it needs to load. However, building it with CGO disabled means the binary is fully static and has no dependencies and runnable on scratch images. I've validated this commit fixes the issue with a local image build.