### PR TITLE
Make Docker image build from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,20 @@
 FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
+FROM golang:alpine as build
+WORKDIR /app/
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+RUN go build -v
+
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build /app/webdav /webdav
 
 EXPOSE 80
-
-COPY webdav /webdav
 
 ENTRYPOINT [ "/webdav" ]


### PR DESCRIPTION
Instead of just adding the built binary to the Docker image, make a full source build in the image creation.
See #47.