### PR TITLE
Add CGO_ENABLED=0 and -a to go build so it builds a static binary.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
-RUN go build -v
+RUN CGO_ENABLED=0 go build -v -a
 
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
Currently the docker image doesn't work because it's copied to a "scratch" image but not build statically:
```
tc@plip:~/webdav$ podman run hacdias/webdav
Trying to pull docker.io/hacdias/webdav...
Getting image source signatures
Copying blob f5ad12cf53f7 [======================================] 3.9MiB / 3.9MiB
Copying blob 424cef1289d8 done  
Copying config 962b7f4980 done  
Writing manifest to image destination
Storing signatures
standard_init_linux.go:211: exec user process caused "no such file or directory"
```
 If you set CGO_ENABLED=0 (and -a just to be sure), it works:
```
tc@plip:~$ podman run amaumene/webdav
Trying to pull docker.io/amaumene/webdav...
Getting image source signatures
Copying blob c64ddd9f5443 done  
Copying blob 909d74dfaaba done  
Copying config c97a9224d5 done  
Writing manifest to image destination
Storing signatures
Listening on [::]:37943
```
