### PR TITLE
feat: per path modify permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ users:
       - regex: false
         allow: false
         path: /some/file
+      - path: /public/access/
+        modify: true
 ```
 
 There are more ways to customize how you run WebDAV through flags and environment variables. Please run `webdav --help` for more information on that.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -118,7 +118,7 @@ func parseUsers(raw []interface{}, c *lib.Config) {
 			}
 
 			if rules, ok := u["rules"].([]interface{}); ok {
-				user.Rules = parseRules(rules, user.Modify)
+				user.Rules = append(c.User.Rules, parseRules(rules, user.Modify)...)
 			}
 
 			user.Handler = &webdav.Handler{

--- a/lib/user.go
+++ b/lib/user.go
@@ -11,6 +11,7 @@ import (
 type Rule struct {
 	Regex  bool
 	Allow  bool
+	Modify bool
 	Path   string
 	Regexp *regexp.Regexp
 }
@@ -26,23 +27,24 @@ type User struct {
 }
 
 // Allowed checks if the user has permission to access a directory/file
-func (u User) Allowed(url string) bool {
+func (u User) Allowed(url string, noModification bool) bool {
 	var rule *Rule
 	i := len(u.Rules) - 1
 
 	for i >= 0 {
 		rule = u.Rules[i]
 
+		isAllowed := rule.Allow && (noModification || rule.Modify)
 		if rule.Regex {
 			if rule.Regexp.MatchString(url) {
-				return rule.Allow
+				return isAllowed
 			}
 		} else if strings.HasPrefix(url, rule.Path) {
-			return rule.Allow
+			return isAllowed
 		}
 
 		i--
 	}
 
-	return true
+	return noModification || u.Modify
 }

--- a/lib/webdav.go
+++ b/lib/webdav.go
@@ -102,7 +102,6 @@ func (c *Config) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Checks for user permissions relatively to this PATH.
-	// TODO: Are any methods missing? Locks? Is OPTIONS already handled above?
 	noModification := r.Method == "GET" || r.Method == "HEAD" ||
 		r.Method == "OPTIONS" || r.Method == "PROPFIND"
 	if !u.Allowed(r.URL.Path, noModification) {

--- a/lib/webdav.go
+++ b/lib/webdav.go
@@ -102,22 +102,16 @@ func (c *Config) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Checks for user permissions relatively to this PATH.
-	if !u.Allowed(r.URL.Path) {
+	// TODO: Are any methods missing? Locks? Is OPTIONS already handled above?
+	noModification := r.Method == "GET" || r.Method == "HEAD" ||
+		r.Method == "OPTIONS" || r.Method == "PROPFIND"
+	if !u.Allowed(r.URL.Path, noModification) {
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}
 
 	if r.Method == "HEAD" {
 		w = newResponseWriterNoBody(w)
-	}
-
-	// If this request modified the files and the user doesn't have permission
-	// to do so, return forbidden.
-	if (r.Method == "PUT" || r.Method == "POST" || r.Method == "MKCOL" ||
-		r.Method == "DELETE" || r.Method == "COPY" || r.Method == "MOVE") &&
-		!u.Modify {
-		w.WriteHeader(http.StatusForbidden)
-		return
 	}
 
 	// Excerpt from RFC4918, section 9.4:


### PR DESCRIPTION
Add a modification setting to each user rule. By default, it matches the user modification setting.
Also merge the top-level rules with per-user rules.

Move modification permission checks into ``User.Allow``. Change the modification "detection" from a black- to a whitelist. Treat locks as a modification, which I think makes sense (see TODO in [lib/webdav.go line 105](https://github.com/mik2k2/webdav/blob/fc962ee8d355245d426ef00099fcedfd5fc16be0/lib/webdav.go#L105)).
