### PR TITLE
feat: add a config option to bypass mime content type sniffing

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -114,8 +114,11 @@ func parseUsers(raw []interface{}, c *lib.Config) {
 			}
 
 			user.Handler = &webdav.Handler{
-				Prefix:     c.User.Handler.Prefix,
-				FileSystem: webdav.Dir(user.Scope),
+				Prefix: c.User.Handler.Prefix,
+				FileSystem: lib.WebDavDir{
+					Dir:     webdav.Dir(user.Scope),
+					NoSniff: c.NoSniff,
+				},
 				LockSystem: webdav.NewMemLS(),
 			}
 
@@ -171,12 +174,16 @@ func readConfig(flags *pflag.FlagSet) *lib.Config {
 			Modify: getOptB(flags, "modify"),
 			Rules:  []*lib.Rule{},
 			Handler: &webdav.Handler{
-				Prefix:     getOpt(flags, "prefix"),
-				FileSystem: webdav.Dir(getOpt(flags, "scope")),
+				Prefix: getOpt(flags, "prefix"),
+				FileSystem: lib.WebDavDir{
+					Dir:     webdav.Dir(getOpt(flags, "scope")),
+					NoSniff: getOptB(flags, "nosniff"),
+				},
 				LockSystem: webdav.NewMemLS(),
 			},
 		},
-		Auth: getOptB(flags, "auth"),
+		Auth:    getOptB(flags, "auth"),
+		NoSniff: getOptB(flags, "nosniff"),
 		Cors: lib.CorsCfg{
 			Enabled:     false,
 			Credentials: false,

--- a/lib/dir.go
+++ b/lib/dir.go
@@ -2,7 +2,6 @@ package lib
 
 import (
 	"context"
-	"log"
 	"mime"
 	"os"
 	"path"
@@ -10,19 +9,17 @@ import (
 	"golang.org/x/net/webdav"
 )
 
-type WebDavFileInfo struct {
+// NoSniffFileInfo wraps any generic FileInfo interface and bypasses mime type sniffing.
+type NoSniffFileInfo struct {
 	os.FileInfo
-	test bool
 }
 
-func (w *WebDavFileInfo) ContentType(ctx context.Context) (string, error) {
-	// TODO: remove debug logging
-	log.Println("NOT sniffing files")
-	if w.FileInfo.IsDir() {
-		return "inode/directory", nil
-	} else if mimeType := mime.TypeByExtension(path.Ext(w.FileInfo.Name())); mimeType != "" {
+func (w NoSniffFileInfo) ContentType(ctx context.Context) (contentType string, err error) {
+	if mimeType := mime.TypeByExtension(path.Ext(w.FileInfo.Name())); mimeType != "" {
+		// We can figure out the mime from the extension.
 		return mimeType, nil
 	} else {
+		// We can't figure out the mime type without sniffing, call it an octet stream.
 		return "application/octet-stream", nil
 	}
 }
@@ -33,22 +30,54 @@ type WebDavDir struct {
 }
 
 func (d WebDavDir) Stat(ctx context.Context, name string) (os.FileInfo, error) {
+	// Skip wrapping if NoSniff is off
 	if !d.NoSniff {
-		// TODO: remove debug logging
-		log.Println("USING THE DEFAULT STAT")
 		return d.Dir.Stat(ctx, name)
 	}
-	// TODO: remove debug logging
-	log.Println("USING THE WRAPPED STAT")
 
 	info, err := d.Dir.Stat(ctx, name)
-
 	if err != nil {
 		return nil, err
 	}
 
-	return WebDavFileInfo{
-		FileInfo: info,
-		test:     false,
-	}, nil
+	return NoSniffFileInfo{info}, nil
+}
+
+func (d WebDavDir) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (webdav.File, error) {
+	// Skip wrapping if NoSniff is off
+	if !d.NoSniff {
+		return d.Dir.OpenFile(ctx, name, flag, perm)
+	}
+
+	file, err := d.Dir.OpenFile(ctx, name, flag, perm)
+	if err != nil {
+		return nil, err
+	}
+
+	return WebDavFile{File: file}, nil
+}
+
+type WebDavFile struct {
+	webdav.File
+}
+
+func (f WebDavFile) Stat() (os.FileInfo, error) {
+	info, err := f.File.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	return NoSniffFileInfo{info}, nil
+}
+
+func (f WebDavFile) Readdir(count int) (fis []os.FileInfo, err error) {
+	fis, err = f.File.Readdir(count)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range fis {
+		fis[i] = NoSniffFileInfo{fis[i]}
+	}
+	return fis, nil
 }

--- a/lib/dir.go
+++ b/lib/dir.go
@@ -1,0 +1,54 @@
+package lib
+
+import (
+	"context"
+	"log"
+	"mime"
+	"os"
+	"path"
+
+	"golang.org/x/net/webdav"
+)
+
+type WebDavFileInfo struct {
+	os.FileInfo
+	test bool
+}
+
+func (w *WebDavFileInfo) ContentType(ctx context.Context) (string, error) {
+	// TODO: remove debug logging
+	log.Println("NOT sniffing files")
+	if w.FileInfo.IsDir() {
+		return "inode/directory", nil
+	} else if mimeType := mime.TypeByExtension(path.Ext(w.FileInfo.Name())); mimeType != "" {
+		return mimeType, nil
+	} else {
+		return "application/octet-stream", nil
+	}
+}
+
+type WebDavDir struct {
+	webdav.Dir
+	NoSniff bool
+}
+
+func (d WebDavDir) Stat(ctx context.Context, name string) (os.FileInfo, error) {
+	if !d.NoSniff {
+		// TODO: remove debug logging
+		log.Println("USING THE DEFAULT STAT")
+		return d.Dir.Stat(ctx, name)
+	}
+	// TODO: remove debug logging
+	log.Println("USING THE WRAPPED STAT")
+
+	info, err := d.Dir.Stat(ctx, name)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return WebDavFileInfo{
+		FileInfo: info,
+		test:     false,
+	}, nil
+}

--- a/lib/webdav.go
+++ b/lib/webdav.go
@@ -20,9 +20,10 @@ type CorsCfg struct {
 // Config is the configuration of a WebDAV instance.
 type Config struct {
 	*User
-	Auth  bool
-	Cors  CorsCfg
-	Users map[string]*User
+	Auth    bool
+	NoSniff bool
+	Cors    CorsCfg
+	Users   map[string]*User
 }
 
 // ServeHTTP determines if the request is for this plugin, and if all prerequisites are met.


### PR DESCRIPTION
This PR adds a config option, `nosniff`, which allows the user to bypass mime sniffing.

The reasoning behind adding this is the 512 byte read at the start of every file can be quite expensive in large and/or networked filesystems. Many users might prefer that mime sniffing be on, and disabling it entirely would be a possibly breaking change so it will remain that way by default.

Let me know if anything in this PR needs changing, and thank you for this project!