### PR TITLE
build: define build pipeline in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
+FROM golang:1.16.15-alpine3.15 as builder
+
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+
+ENV CGO_ENABLED=0
+RUN go build -ldflags '-extldflags "-static"' -o webdav
+
 FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
@@ -5,6 +15,6 @@ FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 EXPOSE 80
-COPY webdav /webdav
+COPY --from=builder /build/webdav /webdav
 
 ENTRYPOINT [ "/webdav" ]


### PR DESCRIPTION
Current Dockerfile require pre-built application binary.
Using multistage build is possible run whole build inside Docker image build. Changes in Dockerfile provide it.