### PR TITLE
feat: loading config file from dir of the executable file path

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -106,6 +108,9 @@ func initConfig() {
 	if cfgFile == "" {
 		v.AddConfigPath(".")
 		v.AddConfigPath("/etc/webdav/")
+		ex, _ := os.Executable()
+		execPath := filepath.Dir(ex)
+		v.AddConfigPath(execPath)
 		v.SetConfigName("config")
 	} else {
 		v.SetConfigFile(cfgFile)


### PR DESCRIPTION
when looking for config file, adding another path besides 
- ./
- /etc/webdav/

which is the path to the executable file `webdav` or `webdav.exe`,

So I can put the binary file and the config file together, and running webdav with this config file from any other working directory.

![image](https://user-images.githubusercontent.com/34023806/188185248-dcc9ebd2-39ac-45ac-9b81-0c779abc110e.png)

like the example in pic,  `config.yml` set the port to 80 and the program read it correctly.

test passed on Windows 11 and Ubuntu 20.04 (WSL2)