### PR TITLE
feat!: more sensible defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ FROM scratch
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /webdav/main /bin/webdav
 
-EXPOSE 80
+EXPOSE 6065
 
 ENTRYPOINT [ "webdav" ]
-CMD [ "-p", "80" ]

--- a/lib/config.go
+++ b/lib/config.go
@@ -16,7 +16,7 @@ const (
 	DefaultCert      = "cert.pem"
 	DefaultKey       = "key.pem"
 	DefaultAddress   = "0.0.0.0"
-	DefaultPort      = 0
+	DefaultPort      = 6065
 	DefaultPrefix    = "/"
 	DefaultLogFormat = "console"
 )
@@ -77,6 +77,7 @@ func ParseConfig(filename string, flags *pflag.FlagSet) (*Config, error) {
 	v.SetDefault("LogFormat", DefaultLogFormat)
 
 	// Other defaults
+	v.SetDefault("Scope", ".")
 	v.SetDefault("CORS.AllowedHeaders", []string{"*"})
 	v.SetDefault("CORS.AllowedHosts", []string{"*"})
 	v.SetDefault("CORS.AllowedMethods", []string{"*"})


### PR DESCRIPTION
Important breaking changes:

- Default port is now 6065
- Default scope is now `.` (current directory)