### PR TITLE
Omit debug information release builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
     flags:
       - '-trimpath'
     ldflags:
-      - '-X github.com/hacdias/webdav/v5/cmd.version={{.Version}}'
+      - '-s -w -X github.com/hacdias/webdav/v5/cmd.version={{.Version}}'
     goos:
       - darwin
       - linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY ./go.sum ./
 RUN go mod download
 
 COPY . /webdav/
-RUN go build -o main -ldflags="-X 'github.com/hacdias/webdav/v5/cmd.version=$VERSION'" .
+RUN go build -o main -trimpath -ldflags="-s -w -X 'github.com/hacdias/webdav/v5/cmd.version=$VERSION'" .
 
 FROM scratch
 


### PR DESCRIPTION
This shrinks the Linux AMD64 build from 14MB to 9.7MB. `-trimpath` was missing from `Dockerfile`, so I've added that for consistency.