### PR TITLE
fix: Pass ExposedHeaders to cors.New

### DIFF
--- a/lib/handler.go
+++ b/lib/handler.go
@@ -63,6 +63,7 @@ func NewHandler(c *Config) (http.Handler, error) {
 			AllowedOrigins:     c.CORS.AllowedHosts,
 			AllowedMethods:     c.CORS.AllowedMethods,
 			AllowedHeaders:     c.CORS.AllowedHeaders,
+			ExposedHeaders:     c.CORS.ExposedHeaders,
 			OptionsPassthrough: false,
 		}).Handler(h), nil
 	}


### PR DESCRIPTION
I noticed the `Access-Control-Expose-Headers` header was missing from the response. I think the config value ended up not being used?

Thank you for this great WebDAV server 🙌 