### PR TITLE
fix: support HEAD method on collections

### DIFF
--- a/lib/handler.go
+++ b/lib/handler.go
@@ -146,8 +146,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	//		"index.html" resource, a human-readable view of the contents of
 	//		the collection, or something else altogether.
 	//
+	//      Similarly, since the definition of HEAD is a GET without a response
+	//      message body, the semantics of HEAD are unmodified when applied to
+	//      collection resources.
+	//
 	// Get, when applied to collection, will return the same as PROPFIND method.
-	if r.Method == "GET" && strings.HasPrefix(r.URL.Path, user.Prefix) {
+	if (r.Method == "GET" || r.Method == "HEAD") && strings.HasPrefix(r.URL.Path, user.Prefix) {
 		info, err := user.FileSystem.Stat(r.Context(), strings.TrimPrefix(r.URL.Path, user.Prefix))
 		if err == nil && info.IsDir() {
 			r.Method = "PROPFIND"


### PR DESCRIPTION
This makes `at.bitfire.dav4jvm` happy when using native WebDAV support in Seedvault on GrapheneOS :)

Unfortunately the response code logic seems to be a bit wrong, logging this warning:

```
http: superfluous response.WriteHeader call from golang.org/x/net/webdav.(*Handler).ServeHTTP (webdav.go:75)
```

Do you have an idea how to fix that?