### PR TITLE
feat: add docker build target of linux/riscv64 to workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64
           push: true
           sbom: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
I recently got a low cost RISC-V SBC(Orange Pi RV2).\
Would you be interested in putting this new architecture into the docker build?