### PR TITLE
docs: fix CORS allowed_hosts example

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ cors:
   credentials: true
   # The following are the default CORS settings when it is enabled.
   allowed_hosts:
-    - *
+    - '*'
   allowed_headers:
     - Authorization
     - Content-Type


### PR DESCRIPTION
The example config yaml cause error message:
```
Error: While parsing config: yaml: line 67: did not find expected alphabetic or numeric character
```