### PR TITLE
feat: add hidden option to omit files from directory listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ debug: false
 # Disable sniffing the files to detect their content type. Default is 'false'.
 noSniff: false
 
+# A list of file name patterns to omit from directory listings. Matching is case
+# insensitive and uses shell patterns (see Go's path.Match) against the base name,
+# so both plain names like 'Thumbs.db' and globs like '*.tmp' work. Hidden files
+# are only left out of listings, they can still be accessed directly by their exact
+# path. Default is none.
+hidden: []
+# hidden:
+#   - .DS_Store
+#   - Thumbs.db
+#   - desktop.ini
+
 # Whether the server runs behind a trusted proxy or not. When this is true,
 # the header X-Forwarded-For will be used for logging the remote addresses
 # of logging attempts (if available).

--- a/lib/config.go
+++ b/lib/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -36,6 +37,7 @@ type Config struct {
 	Key             string
 	Prefix          string
 	NoSniff         bool
+	Hidden          []string
 	NoPassword      bool
 	BehindProxy     bool
 	Log             Log
@@ -236,6 +238,12 @@ func (c *Config) Validate() error {
 	err = c.UserPermissions.Validate()
 	if err != nil {
 		return fmt.Errorf("invalid config: %w", err)
+	}
+
+	for _, pattern := range c.Hidden {
+		if _, err := path.Match(pattern, ""); err != nil {
+			return fmt.Errorf("invalid config: invalid hidden pattern %q: %w", pattern, err)
+		}
 	}
 
 	for i := range c.Users {

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -539,3 +539,23 @@ users:
 	require.True(t, cfg.Users[0].checkPassword("admin"))
 	require.True(t, cfg.Users[1].checkPassword("basic"))
 }
+
+func TestConfigHidden(t *testing.T) {
+	t.Parallel()
+
+	cfg := writeAndParseConfig(t, "", ".yml")
+	require.NoError(t, cfg.Validate())
+	require.Empty(t, cfg.Hidden)
+
+	content := `
+hidden:
+  - Thumbs.db
+  - .DS_Store
+  - "*.tmp"
+`
+	cfg = writeAndParseConfig(t, content, ".yml")
+	require.NoError(t, cfg.Validate())
+	require.Equal(t, []string{"Thumbs.db", ".DS_Store", "*.tmp"}, cfg.Hidden)
+
+	writeAndParseConfigWithError(t, "hidden:\n  - \"[\"\n", ".yml", "invalid hidden pattern")
+}

--- a/lib/handler.go
+++ b/lib/handler.go
@@ -34,7 +34,7 @@ func NewHandler(c *Config) (http.Handler, error) {
 		behindProxy: c.BehindProxy,
 		user: &handlerUser{
 			User:    User{UserPermissions: c.UserPermissions},
-			Handler: buildWebdavHandler(c.UserPermissions, c.Prefix, c.NoSniff, ls, logFunc),
+			Handler: buildWebdavHandler(c.UserPermissions, c.Prefix, c.NoSniff, c.Hidden, ls, logFunc),
 		},
 		users: map[string]*handlerUser{},
 	}
@@ -42,7 +42,7 @@ func NewHandler(c *Config) (http.Handler, error) {
 	for _, u := range c.Users {
 		h.users[u.Username] = &handlerUser{
 			User:    u,
-			Handler: buildWebdavHandler(u.UserPermissions, c.Prefix, c.NoSniff, ls, logFunc),
+			Handler: buildWebdavHandler(u.UserPermissions, c.Prefix, c.NoSniff, c.Hidden, ls, logFunc),
 		}
 	}
 
@@ -71,7 +71,7 @@ func NewHandler(c *Config) (http.Handler, error) {
 // buildWebdavHandler creates the [webdav.Handler] for a set of user permissions,
 // selecting between single-directory and multi-directory backing depending on
 // whether directories are configured.
-func buildWebdavHandler(p UserPermissions, prefix string, noSniff bool, ls webdav.LockSystem, logFunc func(*http.Request, error)) webdav.Handler {
+func buildWebdavHandler(p UserPermissions, prefix string, noSniff bool, hidden []string, ls webdav.LockSystem, logFunc func(*http.Request, error)) webdav.Handler {
 	h := webdav.Handler{
 		Prefix: prefix,
 		Logger: logFunc,
@@ -89,6 +89,10 @@ func buildWebdavHandler(p UserPermissions, prefix string, noSniff bool, ls webda
 			noSniff: noSniff,
 		}
 		h.LockSystem = newLockSystem(ls, p.Directory)
+	}
+
+	if len(hidden) > 0 {
+		h.FileSystem = hiddenFS{FileSystem: h.FileSystem, patterns: hidden}
 	}
 
 	return h

--- a/lib/handler_test.go
+++ b/lib/handler_test.go
@@ -1252,3 +1252,46 @@ rules:
 	require.NoError(t, resp.Body.Close())
 	require.Equal(t, http.StatusCreated, resp.StatusCode)
 }
+
+func TestServerHiddenFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := makeTestDirectory(t, map[string][]byte{
+		"foo.txt":         []byte("foo"),
+		"Thumbs.db":       []byte("thumbs"),
+		".DS_Store":       []byte("ds"),
+		"notes.tmp":       []byte("tmp"),
+		"sub/bar.txt":     []byte("bar"),
+		"sub/desktop.ini": []byte("ini"),
+	})
+
+	srv := makeTestServer(t, "directory: "+dir+"\nhidden:\n  - Thumbs.db\n  - .DS_Store\n  - \"*.tmp\"\n  - desktop.ini\n")
+	client := gowebdav.NewClient(srv.URL, "", "")
+
+	files, err := client.ReadDir("/")
+	require.NoError(t, err)
+
+	names := make([]string, len(files))
+	for i, file := range files {
+		names[i] = file.Name()
+	}
+	sort.Strings(names)
+	require.Equal(t, []string{"foo.txt", "sub"}, names)
+
+	// The listing of a sub collection is filtered as well.
+	files, err = client.ReadDir("/sub")
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, "bar.txt", files[0].Name())
+
+	// Hidden files are only omitted from listings, they can still be read by
+	// their exact path.
+	data, err := client.Read("/Thumbs.db")
+	require.NoError(t, err)
+	require.EqualValues(t, []byte("thumbs"), data)
+
+	// A visible file keeps working as usual.
+	data, err = client.Read("/foo.txt")
+	require.NoError(t, err)
+	require.EqualValues(t, []byte("foo"), data)
+}

--- a/lib/hidden.go
+++ b/lib/hidden.go
@@ -1,0 +1,63 @@
+package lib
+
+import (
+	"context"
+	"os"
+	"path"
+	"strings"
+
+	"golang.org/x/net/webdav"
+)
+
+// hiddenFS wraps a [webdav.FileSystem] and omits entries whose base name matches
+// one of the configured patterns from directory listings. The files themselves
+// are left untouched and can still be accessed directly by their exact path,
+// they are only removed from the parent collection's listing.
+type hiddenFS struct {
+	webdav.FileSystem
+	patterns []string
+}
+
+func (h hiddenFS) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (webdav.File, error) {
+	file, err := h.FileSystem.OpenFile(ctx, name, flag, perm)
+	if err != nil {
+		return nil, err
+	}
+
+	return hiddenFile{File: file, patterns: h.patterns}, nil
+}
+
+type hiddenFile struct {
+	webdav.File
+	patterns []string
+}
+
+func (f hiddenFile) Readdir(count int) ([]os.FileInfo, error) {
+	fis, err := f.File.Readdir(count)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make([]os.FileInfo, 0, len(fis))
+	for _, fi := range fis {
+		if matchHidden(f.patterns, fi.Name()) {
+			continue
+		}
+		filtered = append(filtered, fi)
+	}
+	return filtered, nil
+}
+
+// matchHidden reports whether name matches any of the patterns. Matching is case
+// insensitive and uses [path.Match] against the base name, so both plain names
+// like "Thumbs.db" and globs like "*.tmp" work. Patterns are validated when the
+// configuration is parsed, so a bad pattern here is simply treated as no match.
+func matchHidden(patterns []string, name string) bool {
+	name = strings.ToLower(name)
+	for _, pattern := range patterns {
+		if ok, err := path.Match(strings.ToLower(pattern), name); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #221.

This adds a `hidden` config option that takes a list of shell patterns (Go's `path.Match`, matched case-insensitively against the base name). Any entry whose name matches is dropped from directory listings. It's aimed at the usual junk files people asked about in the issue, `.DS_Store`, `Thumbs.db`, `desktop.ini`, and globs like `*.tmp` work too.

A few notes on the scope:

- It only affects listings. A hidden file is still reachable by its exact path, same idea as dotfiles being hidden from `ls` but not gone. That keeps clients that write those files (Finder and friends) working.
- It's wired in the same place as `noSniff`, as a thin `webdav.FileSystem` wrapper that is only applied when at least one pattern is set, so the default behaviour is unchanged.
- Patterns are validated when the config is parsed, so a bad pattern fails fast with a clear error.

Added tests for the config parsing/validation and for the server actually filtering both the root and a sub collection while still serving a hidden file directly. `go test ./...`, `go vet ./...` and golangci-lint are all clean.