### PR TITLE
fix: skip destination lock condition check for MOVE operations

### DIFF
--- a/lib/locksystem.go
+++ b/lib/locksystem.go
@@ -70,6 +70,15 @@ func (l *lockSystem) Confirm(now time.Time, name0, name1 string, conditions ...w
 			return nil, err
 		}
 	}
+	// When both source (name0) and destination (name1) are provided — as in
+	// a MOVE — the If header conditions typically only cover the source
+	// resource. The default MemLS.Confirm requires BOTH names to match the
+	// same conditions, which fails because the destination has no matching
+	// lock. Pass only the source when it is present so that only the source
+	// lock is verified against the If conditions.
+	if name0 != "" {
+		name1 = ""
+	}
 
 	return l.LockSystem.Confirm(now, name0, name1, conditions...)
 }

--- a/lib/locksystem_test.go
+++ b/lib/locksystem_test.go
@@ -77,3 +77,63 @@ func TestMultiDirLockSystemUsesSlashSeparatedKeys(t *testing.T) {
 	require.Equal(t, path.Join(filepath.ToSlash(mounts[0].Path), "report.txt"), key)
 	require.NotContains(t, key, "\\")
 }
+
+func TestLockSystemConfirmSkipsDestinationForMove(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ls := newLockSystem(webdav.NewMemLS(), dir)
+	now := time.Now()
+
+	// Create a lock on the source file (simulating temp file lock).
+	srcToken, err := ls.Create(now, webdav.LockDetails{
+		Root:      "/temp.txt",
+		Duration:  time.Minute,
+		ZeroDepth: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = ls.Unlock(time.Now(), srcToken)
+	})
+
+	// MOVE: confirm with source lock and no destination lock.
+	// This should succeed — the If header only covers the source.
+	release, err := ls.Confirm(now, "/temp.txt", "/original.txt", webdav.Condition{
+		Token: srcToken,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, release)
+	release()
+
+	// MOVE without any valid lock should fail.
+	_, err = ls.Confirm(now, "/temp.txt", "/original.txt")
+	require.ErrorIs(t, err, webdav.ErrConfirmationFailed)
+}
+
+func TestLockSystemConfirmStillChecksDestinationWhenNoSource(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ls := newLockSystem(webdav.NewMemLS(), dir)
+	now := time.Now()
+
+	// Create a lock on the destination file.
+	dstToken, err := ls.Create(now, webdav.LockDetails{
+		Root:      "/dest.txt",
+		Duration:  time.Minute,
+		ZeroDepth: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = ls.Unlock(time.Now(), dstToken)
+	})
+
+	// When name0 is empty (e.g. COPY with no source lock),
+	// destination conditions should still be checked.
+	release, err := ls.Confirm(now, "", "/dest.txt", webdav.Condition{
+		Token: dstToken,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, release)
+	release()
+}


### PR DESCRIPTION
# fix: skip destination lock condition check for MOVE operations

## Problem

When a Windows native WebDAV client (WebClient / `net use` / Explorer "映射网络驱动器") saves a file, it returns **412 Precondition Failed**.

### Windows WebDAV save workflow

1. `LOCK /original.xlsx` → token T1
2. Create temp file `~tmp*.TMP`
3. `LOCK /~tmp*.TMP` → token T2
4. `PUT /~tmp*.TMP` with `If: (<T2>)`
5. `UNLOCK /original.xlsx` (T1)
6. `UNLOCK /~tmp*.TMP` (T2)
7. `LOCK /~tmp*.TMP` → token T3
8. `MOVE /~tmp*.TMP → /original.xlsx` with `If: (<T3>)` → **412**

### Root cause

Step 8 calls `confirmLocks(r, src, dst)` which calls:

```go
h.LockSystem.Confirm(now, src, dst, conditions...)
// → MemLS.Confirm(now, tempPath, originalPath, [Token: T3])
```

`MemLS.Confirm()` requires **both** source and destination to match the If conditions via `lookup()`. The If header only has T3 (temp file's lock), but the original file has no lock (released in step 5). So `lookup(originalPath, [Token: T3])` returns nil → `ErrConfirmationFailed` → 412.

## Fix

When `name0` (source) is non-empty — indicating a MOVE operation — pass only `name0` to the underlying Confirm. This verifies the source lock while skipping the unnecessary destination condition check.

```diff
 func (l *lockSystem) Confirm(now time.Time, name0, name1 string, conditions ...webdav.Condition) (release func(), err error) {
 	// ... resolve paths unchanged ...

+	// For MOVE operations, the If header conditions typically only cover
+	// the source resource. MemLS.Confirm requires both names to match the
+	// same conditions, which fails when the destination has no lock.
+	// Clear destination conditions so only the source is verified.
+	if name0 != "" {
+		name1 = ""
+	}
+
 	return l.LockSystem.Confirm(now, name0, name1, conditions...)
 }
```

## Test

```go
func TestLockSystemConfirmSkipsDestinationForMove(t *testing.T) {
	dir := t.TempDir()
	ls := newLockSystem(webdav.NewMemLS(), dir)
	now := time.Now()

	srcToken, err := ls.Create(now, webdav.LockDetails{
		Root: "/temp.txt", Duration: time.Minute, ZeroDepth: true,
	})
	require.NoError(t, err)

	// MOVE with source lock, no destination lock — should succeed.
	release, err := ls.Confirm(now, "/temp.txt", "/original.txt",
		webdav.Condition{Token: srcToken})
	require.NoError(t, err)
	release()

	// MOVE without any lock — should fail.
	_, err = ls.Confirm(now, "/temp.txt", "/original.txt")
	require.ErrorIs(t, err, webdav.ErrConfirmationFailed)
}
```

## Affected clients

- Windows native WebDAV client (WebClient service / `net use` / Explorer)
- Any WebDAV client that releases both locks before performing a MOVE rename
