### PR TITLE
fix: use case-insensitive matching in path-based permission rules

### DIFF
--- a/lib/permissions.go
+++ b/lib/permissions.go
@@ -32,7 +32,7 @@ func (r *Rule) Matches(path string) bool {
 		return r.Regex.MatchString(path)
 	}
 
-	return strings.HasPrefix(path, r.Path)
+	return len(path) >= len(r.Path) && strings.EqualFold(path[:len(r.Path)], r.Path)
 }
 
 // matchesCollection checks if [Rule] names path as the collection it governs,
@@ -43,7 +43,7 @@ func (r *Rule) matchesCollection(path string) bool {
 		return false
 	}
 
-	return path == strings.TrimSuffix(r.Path, "/")
+	return strings.EqualFold(path, strings.TrimSuffix(r.Path, "/"))
 }
 
 type RulesBehavior string


### PR DESCRIPTION
Rule.Matches and matchesCollection use case-sensitive string comparison (strings.HasPrefix / ==) to check request paths against rule paths. On case-insensitive filesystems (macOS APFS, Windows NTFS), this allows bypassing deny rules by changing path case (e.g. /SECRET/ vs /secret/).

Switch to strings.EqualFold so the permission layer agrees with the filesystem on path equivalence.